### PR TITLE
fix: scrape the right page

### DIFF
--- a/build/scraper.js
+++ b/build/scraper.js
@@ -19,8 +19,8 @@ class Scraper {
     this.posts = [];
   }
 
-  async #fetch() {
-    return (await fetch(baseUrl)).text();
+  async #fetch(url) {
+    return (await fetch(url)).text();
   }
 
   /**
@@ -29,7 +29,7 @@ class Scraper {
    * @returns {Promise<number>} total number of pages
    */
   async getPageNumbers() {
-    const html = await this.#fetch();
+    const html = await this.#fetch(baseUrl);
     const $ = cheerio.load(html);
     const text = $('a[id^="elPagination"]').text().trim().split(' ');
 
@@ -46,7 +46,7 @@ class Scraper {
    * @returns {void}
    */
   async scrape(url, bar) {
-    const html = await this.#fetch();
+    const html = await this.#fetch(url);
     const $ = cheerio.load(html);
     const selector = $('ol[id^="elTable"] .ipsDataItem');
 
@@ -95,7 +95,7 @@ class Scraper {
    * @returns {void}
    */
   async scrapePost(url, data) {
-    const html = await this.#fetch();
+    const html = await this.#fetch(url);
     const $ = cheerio.load(html);
     const article = $('article').first();
     const post = article.find('div[data-role="commentContent"]');

--- a/build/scraper.js
+++ b/build/scraper.js
@@ -19,7 +19,7 @@ class Scraper {
     this.posts = [];
   }
 
-  async #fetch(url) {
+  async #fetch(url = baseUrl) {
     return (await fetch(url)).text();
   }
 
@@ -29,7 +29,7 @@ class Scraper {
    * @returns {Promise<number>} total number of pages
    */
   async getPageNumbers() {
-    const html = await this.#fetch(baseUrl);
+    const html = await this.#fetch();
     const $ = cheerio.load(html);
     const text = $('a[id^="elPagination"]').text().trim().split(' ');
 


### PR DESCRIPTION
### What did you fix?
Fixing only the first page get scraped

closes #132 

---

### Reproduction steps

---

### Evidence/screenshot/link to line

https://github.com/WFCD/warframe-patchlogs/blob/dd2e6cdc0d83884c353b4aadd04ae87974562bd3/build/scraper.js#L22-L24
https://github.com/WFCD/warframe-patchlogs/blob/dd2e6cdc0d83884c353b4aadd04ae87974562bd3/build/scraper.js#L31-L33
https://github.com/WFCD/warframe-patchlogs/blob/dd2e6cdc0d83884c353b4aadd04ae87974562bd3/build/scraper.js#L48-L50
https://github.com/WFCD/warframe-patchlogs/blob/dd2e6cdc0d83884c353b4aadd04ae87974562bd3/build/scraper.js#L97-L99

### Considerations
- Does this contain a new dependency? **[Yes/No]**
- Does this introduce opinionated data formatting or manual data entry? **[Yes/No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[Yes/No]**
- Have I run the linter? **[Yes/No]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix/Feature/Enhancement/Docs/Maintenance]**
